### PR TITLE
feat: add SignIn page

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,16 +1,13 @@
 import { useContext, useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { AuthContext } from "../../context/AuthContext";
-import { SignInModal } from "../shared/SignInModal";
 import { User } from "../shared/User";
 import { ModeToggle } from "../shared/ModeToggler";
-import { LoadingSpinner } from "../ui/loading-spinner";
 import { BackButton } from "../shared/BackButton";
-import { Button, buttonVariants } from "../ui/button";
+import { buttonVariants } from "../ui/button";
 import { RiEditLine } from "@remixicon/react";
 export default function Header() {
-  const { currentUser, loading } = useContext(AuthContext);
-  const [showModal, setShowModal] = useState(false);
+  const { currentUser } = useContext(AuthContext);
   const headerRef = useRef(null);
   const [scrollDirection, setScrollDirection] = useState(null);
   const [lastScrollY, setLastScrollY] = useState(0);
@@ -51,7 +48,7 @@ export default function Header() {
       >
         <div className="container px-5 sm:px-8 flex justify-between items-center py-3 px-sm">
           <div className="flex items-center gap-3">
-            {pathname !== "/" && <BackButton />}
+            {currentUser && pathname !== "/" && <BackButton />}
             <Link
               to="/"
               className="text-2xl font-semibold text-zinc-50 flex items-center gap-3"
@@ -96,22 +93,10 @@ export default function Header() {
                 <ModeToggle />
               </li>
               <li className="ml-2 sm:ml-0">{currentUser && <User />}</li>
-              {!currentUser && (
-                <li>
-                  {loading ? (
-                    <LoadingSpinner />
-                  ) : (
-                    <Button size="lg" onClick={() => setShowModal(true)}>
-                      Sign In
-                    </Button>
-                  )}
-                </li>
-              )}
             </ul>
           </nav>
         </div>
       </header>
-      <SignInModal showModal={showModal} onCancel={() => setShowModal(false)} />
     </>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,24 +13,46 @@ import "remixicon/fonts/remixicon.css";
 import App from "./App.jsx";
 import "./index.css";
 import { fetchPost } from "./services/fetchPost.js";
+import { SignIn } from "./pages/SignIn.jsx";
+import { PrivateRouter } from "./pages/PrivateRouter.jsx";
 const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
     errorElement: <NotFound />,
     children: [
-      { path: "/", element: <Posts /> },
+      { path: "/signin", element: <SignIn /> },
+      {
+        path: "/",
+        element: (
+          <PrivateRouter>
+            <Posts />
+          </PrivateRouter>
+        ),
+      },
       {
         path: "/post/:id",
-        element: <Post />,
+        element: (
+          <PrivateRouter>
+            <Post />
+          </PrivateRouter>
+        ),
       },
       {
         path: "/create",
-        element: <CreatePost />,
+        element: (
+          <PrivateRouter>
+            <CreatePost />
+          </PrivateRouter>
+        ),
       },
       {
         path: "/edit/:id",
-        element: <EditPost />,
+        element: (
+          <PrivateRouter>
+            <EditPost />
+          </PrivateRouter>
+        ),
         loader: async ({ params }) => {
           const postId = params.id;
           const post = await fetchPost(postId);
@@ -42,20 +64,36 @@ const router = createBrowserRouter([
       },
       {
         path: "/bookmarks",
-        element: <Bookmarks />,
+        element: (
+          <PrivateRouter>
+            <Bookmarks />
+          </PrivateRouter>
+        ),
         loader: () => import("./pages/Bookmarks.jsx"),
       },
       {
         path: "/my-posts",
-        element: <MyPosts />,
+        element: (
+          <PrivateRouter>
+            <MyPosts />
+          </PrivateRouter>
+        ),
       },
       {
         path: "/drafts",
-        element: <MyPosts />,
+        element: (
+          <PrivateRouter>
+            <MyPosts />
+          </PrivateRouter>
+        ),
       },
       {
         path: "/users/:id",
-        element: <UserProfile />,
+        element: (
+          <PrivateRouter>
+            <UserProfile />
+          </PrivateRouter>
+        ),
       },
     ],
   },

--- a/src/pages/PrivateRouter.jsx
+++ b/src/pages/PrivateRouter.jsx
@@ -1,0 +1,13 @@
+import { Navigate } from "react-router-dom";
+import { useContext } from "react";
+import { AuthContext } from "../context/AuthContext";
+
+export const PrivateRouter = ({ children }) => {
+  const { currentUser } = useContext(AuthContext);
+
+  if (!currentUser) {
+    return <Navigate to="/signin" />;
+  }
+
+  return children;
+};

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,0 +1,72 @@
+import { RiUserLine } from "@remixicon/react";
+import { GoogleIcon } from "../components/shared/GoogleIcon";
+import { Button } from "../components/ui/button";
+import { useContext } from "react";
+import { AuthContext } from "../context/AuthContext";
+import { Navigate } from "react-router-dom";
+import { LoadingSpinner } from "../components/ui/loading-spinner";
+
+export const SignIn = () => {
+  const { signIn, signInAsGuest, currentUser, loading } =
+    useContext(AuthContext);
+
+  /**
+   * Handle Sign In With Google
+   */
+  const handleGoogleSignIn = () => {
+    signIn();
+  };
+
+  /**
+   * Handle Sign In as Guest
+   */
+  const handleGuestSignIn = () => {
+    signInAsGuest();
+  };
+
+  /**
+   * Redirect user to home page if already signed in
+   */
+  if (currentUser) {
+    return <Navigate to="/" />;
+  }
+
+  if (loading) {
+    return (
+      <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur">
+        <div className="flex justify-center items-center h-full">
+          <LoadingSpinner />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-5xl flex justify-center items-center h-[90dvh]">
+      <div className="flex flex-col justify-center items-center gap-6 w-full -translate-y-1/4">
+        <h1 className="text-2xl md:text-4xl font-bold">Welcome to Blogify</h1>
+        <div className="flex flex-col items-stretch gap-2 w-full max-w-md p-6 border border-border rounded-lg">
+          <Button
+            size="lg"
+            variant="default"
+            className="md:text-base flex gap-[10px] h-11"
+            onClick={handleGoogleSignIn}
+          >
+            <GoogleIcon />
+            Sign in with Google
+          </Button>
+          <span className="text-center text-muted-foreground">OR</span>
+          <Button
+            size="lg"
+            variant="outline"
+            className="md:text-base flex gap-[10px] h-11"
+            onClick={handleGuestSignIn}
+          >
+            <RiUserLine size={20} />
+            Continue as Guest
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
- Implemented a `SignIn` page with two options: Google sign-in and sign in as a guest.
- Added `PrivateRouter` to handle redirection to the `SignIn` page if the user is not signed in.
- Removed the sign-in button from the Header component.